### PR TITLE
메모리 캐시 적용

### DIFF
--- a/Jetflix/Jetflix/Data/Repository/ContentRepository.swift
+++ b/Jetflix/Jetflix/Data/Repository/ContentRepository.swift
@@ -10,6 +10,7 @@ import Foundation
 final class ContentRepository: ContentRepositoryProtocol {
     private let apiCaller = APICaller.shared
     private let contentStorage = ContentStorage()
+    private var searchMemoryCache: [String: [Content]] = [:]
 }
 
 //MARK: - Fetch TBMS Data
@@ -38,7 +39,14 @@ extension ContentRepository {
 //MARK: - Search
 extension ContentRepository {
     func search(with query: String) async throws -> [Content] {
-        return try await apiCaller.search(with: query)
+        if let cache = searchMemoryCache[query] {
+            return cache
+        }
+        
+        let contents = try await apiCaller.search(with: query)
+        searchMemoryCache[query] = contents
+        
+        return contents
     }
 }
 

--- a/Jetflix/Jetflix/Data/Repository/YoutubeRepository.swift
+++ b/Jetflix/Jetflix/Data/Repository/YoutubeRepository.swift
@@ -9,8 +9,16 @@ import Foundation
 
 final class YoutubeRepository: YoutubeRepositoryProtocol {
     private let apiCaller = APICaller.shared
+    private var memoryCache: [String: VideoElement] = [:]
     
     func getMovieTrailer(title: String) async throws -> VideoElement {
-        return try await apiCaller.getMovieFromYoutube(with: title)
+        if let cache = memoryCache[title] {
+            return cache
+        }
+        
+        let videoElement = try await apiCaller.getMovieFromYoutube(with: title)
+        memoryCache[title] = videoElement
+        
+        return videoElement
     }
 }

--- a/Jetflix/Jetflix/Presentation/Search/View/SearchResultsViewController.swift
+++ b/Jetflix/Jetflix/Presentation/Search/View/SearchResultsViewController.swift
@@ -45,11 +45,18 @@ class SearchResultsViewController: UIViewController {
         searchResultsCollectionView.frame = view.bounds
     }
     
-    //MARK: - Methods
+    //MARK: - Setup
     private func setupUI() {
         view.backgroundColor = .systemBackground
         
         view.addSubview(searchResultsCollectionView)
+    }
+    
+    func clearData() {
+        contents.removeAll()
+        DispatchQueue.main.async { [weak self] in
+            self?.searchResultsCollectionView.reloadData()
+        }
     }
 }
 

--- a/Jetflix/Jetflix/Presentation/Search/View/SearchViewController.swift
+++ b/Jetflix/Jetflix/Presentation/Search/View/SearchViewController.swift
@@ -111,6 +111,11 @@ class SearchViewController: UIViewController {
             }
     }
     
+    private func cancelSearch() {
+        cancelTextInputTimer()
+        (searchController.searchResultsController as? SearchResultsViewController)?.clearData()
+    }
+    
     private func presentVideoPreivewWith(content: Content) {
         let videoPreviewVC = VideoPreviewViewController()
         videoPreviewVC.content = content
@@ -152,6 +157,7 @@ extension SearchViewController: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let query = searchBar.text,
                 !query.trimmingCharacters(in: .whitespaces).isEmpty else {
+            cancelSearch()
             return
         }
         
@@ -164,6 +170,7 @@ extension SearchViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         guard let query = searchController.searchBar.text,
               !query.trimmingCharacters(in: .whitespaces).isEmpty else {
+            cancelSearch()
             return
         }
         


### PR DESCRIPTION
Search API에 메모리 캐시 적용
- Struct이고 자동 메모리 정리 기능이 불필요하므로 NSCache 대신 Dictionary 사용
- SearchBar가 Empty일 때 SearchResults의 데이터 초기화